### PR TITLE
Switch track remote

### DIFF
--- a/denops/@ddu-kinds/git_tag.ts
+++ b/denops/@ddu-kinds/git_tag.ts
@@ -6,6 +6,7 @@ import {
 import { input } from "https://deno.land/x/denops_std@v5.0.1/helper/mod.ts";
 
 export type ActionData = {
+  kind: "tag";
   tag: string;
 };
 

--- a/denops/ddu-source-git/git_branch/switch.ts
+++ b/denops/ddu-source-git/git_branch/switch.ts
@@ -7,7 +7,10 @@ export async function switchLocalBranch(
   return await dispatchCommand("git", ["switch", branchName], repoDir);
 }
 
-export async function switchRemoteBranch(repoDir: string, refName: string) {
+export async function switchRemoteBranch(
+  repoDir: string,
+  refName: string,
+) {
   return await dispatchCommand(
     "git",
     ["switch", "--detach", refName],

--- a/denops/ddu-source-git/git_ref/main.ts
+++ b/denops/ddu-source-git/git_ref/main.ts
@@ -18,7 +18,7 @@ export async function collectItems(
     const item = parseGitRef(gitRef);
     if (
       item.kind === "git_branch" &&
-      item.action && "isRemote" in item.action && !item.action.isRemote
+      item.action?.kind == "branch" && !item.action.isRemote
     ) {
       const remoteState = cache.getState(item.action.branch);
       item.action.remoteState = remoteState;
@@ -35,18 +35,24 @@ function parseGitRef(gitRef: string): Item<ActionData> {
       word: gitRef,
       display: branch,
       kind: "git_branch",
-      action: { branch: branch, isRemote: false },
+      action: {
+        kind: "branch",
+        branch: branch,
+        isRemote: false,
+        remoteState: "equal",
+      },
     };
   }
 
   if (gitRef.startsWith("refs/remotes/")) {
     const branch = gitRef.slice("refs/remotes/".length);
+    const localBranch = branch.slice(branch.indexOf("/") + 1);
 
     return {
       word: gitRef,
       display: branch,
       kind: "git_branch",
-      action: { branch: branch, isRemote: true },
+      action: { kind: "branch", branch, localBranch, isRemote: true },
     };
   }
 
@@ -57,7 +63,7 @@ function parseGitRef(gitRef: string): Item<ActionData> {
       word: gitRef,
       display: tag,
       kind: "git_tag",
-      action: { tag: tag },
+      action: { kind: "tag", tag: tag },
     };
   }
 

--- a/doc/ddu-source-git.txt
+++ b/doc/ddu-source-git.txt
@@ -72,6 +72,19 @@ EXAMPLES                                             *ddu-source-git-examples*
 <
 
 ==============================================================================
+KINDS                                                           *ddu-kind-git*
+
+------------------------------------------------------------------------------
+GITBRANCH KIND PARAMS                             *ddu-kind-git_branch-params*
+
+switchToTrackRemote            *ddu-kind-git_branch-param-switchToTrackRemote*
+
+		If it is true, when "switch" action is called for a remote
+		branch, new branch with same name is created to track the
+		remote one.
+		See `--guess` option in `git switch --help` for detail.
+
+==============================================================================
 ACTIONS                                               *ddu-source-git-actions*
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
- Add new param 'switchToTrackRemote' for kind-git_ref
- When it is true, 'switch' action tries to switch new branch tracking the remote branch

fix: tennashi#4